### PR TITLE
Remove :dimensions from option hash

### DIFF
--- a/lib/dimensions-rails.rb
+++ b/lib/dimensions-rails.rb
@@ -15,7 +15,7 @@ module Dimensions
       # https://developers.google.com/speed/docs/best-practices/rendering#SpecifyImageDimensions
       #
       def image_tag source, options = {}
-        disable_dimensions = options[:dimensions] == false
+        disable_dimensions = options.delete(:dimensions) == false
 
         unless disable_dimensions or options[:size] or options[:width] or options[:height]
           fs_path = ::Rails.application.assets.find_asset(source)


### PR DESCRIPTION
This avoids adding dimensions="false" to the img tag and fixes #10.
